### PR TITLE
Update PlannerMdParser to support appt commands

### DIFF
--- a/src/main/java/seedu/plannermd/commons/core/Messages.java
+++ b/src/main/java/seedu/plannermd/commons/core/Messages.java
@@ -6,6 +6,7 @@ package seedu.plannermd.commons.core;
 public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_UNKNOWN_FLAG = "Unknown flag";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX = "The patient index provided is invalid";
     public static final String MESSAGE_INVALID_DOCTOR_DISPLAYED_INDEX = "The doctor index provided is invalid";

--- a/src/main/java/seedu/plannermd/logic/commands/apptcommand/AddAppointmentCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/apptcommand/AddAppointmentCommand.java
@@ -1,0 +1,13 @@
+package seedu.plannermd.logic.commands.apptcommand;
+
+import seedu.plannermd.logic.commands.CommandResult;
+import seedu.plannermd.logic.commands.exceptions.CommandException;
+import seedu.plannermd.model.Model;
+
+public class AddAppointmentCommand extends AppointmentCommand {
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return null;
+    }
+}

--- a/src/main/java/seedu/plannermd/logic/commands/apptcommand/AppointmentCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/apptcommand/AppointmentCommand.java
@@ -1,0 +1,8 @@
+package seedu.plannermd.logic.commands.apptcommand;
+
+import seedu.plannermd.logic.commands.Command;
+
+public abstract class AppointmentCommand extends Command {
+
+    public static final String COMMAND_WORD = "appt";
+}

--- a/src/main/java/seedu/plannermd/logic/commands/apptcommand/AppointmentCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/apptcommand/AppointmentCommand.java
@@ -5,4 +5,15 @@ import seedu.plannermd.logic.commands.Command;
 public abstract class AppointmentCommand extends Command {
 
     public static final String COMMAND_WORD = "appt";
+    public static final String MESSAGE_USAGE =
+            COMMAND_WORD + "{FLAG} {ARGUMENTS}: Executes appointment command given by flag tag\n"
+            + "Commands: \n";
+            //ADD
+            //EDIT
+            //DELETE
+            //FILTER
+            //FILTER UPCOMING
+            //LIST
+            //TODO: Append Commands Usages
+
 }

--- a/src/main/java/seedu/plannermd/logic/commands/apptcommand/DeleteAppointmentCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/apptcommand/DeleteAppointmentCommand.java
@@ -1,0 +1,13 @@
+package seedu.plannermd.logic.commands.apptcommand;
+
+import seedu.plannermd.logic.commands.CommandResult;
+import seedu.plannermd.logic.commands.exceptions.CommandException;
+import seedu.plannermd.model.Model;
+
+public class DeleteAppointmentCommand extends AppointmentCommand {
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return null;
+    }
+}

--- a/src/main/java/seedu/plannermd/logic/commands/apptcommand/EditAppointmentCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/apptcommand/EditAppointmentCommand.java
@@ -1,0 +1,15 @@
+package seedu.plannermd.logic.commands.apptcommand;
+
+import seedu.plannermd.logic.commands.CommandResult;
+import seedu.plannermd.logic.commands.exceptions.CommandException;
+import seedu.plannermd.model.Model;
+
+public class EditAppointmentCommand extends AppointmentCommand {
+
+    public static final String COMMAND_FLAG = "-e";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return null;
+    }
+}

--- a/src/main/java/seedu/plannermd/logic/commands/apptcommand/EditAppointmentCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/apptcommand/EditAppointmentCommand.java
@@ -6,8 +6,6 @@ import seedu.plannermd.model.Model;
 
 public class EditAppointmentCommand extends AppointmentCommand {
 
-    public static final String COMMAND_FLAG = "-e";
-
     @Override
     public CommandResult execute(Model model) throws CommandException {
         return null;

--- a/src/main/java/seedu/plannermd/logic/commands/apptcommand/FilterAppointmentCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/apptcommand/FilterAppointmentCommand.java
@@ -1,0 +1,13 @@
+package seedu.plannermd.logic.commands.apptcommand;
+
+import seedu.plannermd.logic.commands.CommandResult;
+import seedu.plannermd.logic.commands.exceptions.CommandException;
+import seedu.plannermd.model.Model;
+
+public class FilterAppointmentCommand extends AppointmentCommand {
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return null;
+    }
+}

--- a/src/main/java/seedu/plannermd/logic/commands/apptcommand/FilterUpcomingAppointmentCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/apptcommand/FilterUpcomingAppointmentCommand.java
@@ -1,0 +1,13 @@
+package seedu.plannermd.logic.commands.apptcommand;
+
+import seedu.plannermd.logic.commands.CommandResult;
+import seedu.plannermd.logic.commands.exceptions.CommandException;
+import seedu.plannermd.model.Model;
+
+public class FilterUpcomingAppointmentCommand extends AppointmentCommand {
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return null;
+    }
+}

--- a/src/main/java/seedu/plannermd/logic/commands/apptcommand/ListAppointmentCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/apptcommand/ListAppointmentCommand.java
@@ -1,0 +1,13 @@
+package seedu.plannermd.logic.commands.apptcommand;
+
+import seedu.plannermd.logic.commands.CommandResult;
+import seedu.plannermd.logic.commands.exceptions.CommandException;
+import seedu.plannermd.model.Model;
+
+public class ListAppointmentCommand extends AppointmentCommand {
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        return null;
+    }
+}

--- a/src/main/java/seedu/plannermd/logic/commands/tagcommand/AddDoctorTagCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/tagcommand/AddDoctorTagCommand.java
@@ -2,7 +2,6 @@ package seedu.plannermd.logic.commands.tagcommand;
 
 
 import static java.util.Objects.requireNonNull;
-import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.HashSet;
@@ -23,8 +22,8 @@ import seedu.plannermd.model.tag.Tag;
 public class AddDoctorTagCommand extends AddTagCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a tag to the doctor identified "
-            + "by the index number used in the displayed doctor list.\n" + "Parameters: " + PREFIX_ID
-            + "ID (must be a positive integer) " + PREFIX_TAG + "TAG\n" + "Example: " + COMMAND_WORD + " " + PREFIX_ID
+            + "by the index number used in the displayed doctor list.\n" + "Parameters: "
+            + "INDEX (must be a positive integer) " + PREFIX_TAG + "TAG\n" + "Example: " + COMMAND_WORD + " "
             + "1 " + PREFIX_TAG + "healthy";
 
     public static final String MESSAGE_ADD_TAG_SUCCESS = "Added tag to Doctor: %1$s";

--- a/src/main/java/seedu/plannermd/logic/commands/tagcommand/AddPatientTagCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/tagcommand/AddPatientTagCommand.java
@@ -1,7 +1,6 @@
 package seedu.plannermd.logic.commands.tagcommand;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.HashSet;
@@ -22,8 +21,8 @@ import seedu.plannermd.model.tag.Tag;
 public class AddPatientTagCommand extends AddTagCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a tag to the patient identified "
-            + "by the index number used in the displayed patient list.\n" + "Parameters: " + PREFIX_ID
-            + "ID (must be a positive integer) " + PREFIX_TAG + "TAG\n" + "Example: " + COMMAND_WORD + " " + PREFIX_ID
+            + "by the index number used in the displayed patient list.\n" + "Parameters: "
+            + "INDEX (must be a positive integer) " + PREFIX_TAG + "TAG\n" + "Example: " + COMMAND_WORD + " "
             + "1 " + PREFIX_TAG + "healthy";
 
     public static final String MESSAGE_ADD_TAG_SUCCESS = "Added tag to Patient: %1$s";

--- a/src/main/java/seedu/plannermd/logic/commands/tagcommand/DeleteDoctorTagCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/tagcommand/DeleteDoctorTagCommand.java
@@ -2,7 +2,6 @@ package seedu.plannermd.logic.commands.tagcommand;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.plannermd.commons.core.Messages.MESSAGE_INVALID_DOCTOR_DISPLAYED_INDEX;
-import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.HashSet;
@@ -22,8 +21,8 @@ import seedu.plannermd.model.tag.Tag;
 public class DeleteDoctorTagCommand extends DeleteTagCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a tag from the doctor identified "
-            + "by the index number used in the displayed doctor list.\n" + "Parameters: " + PREFIX_ID
-            + "ID (must be a positive integer) " + PREFIX_TAG + "TAG\n" + "Example: " + COMMAND_WORD + " " + PREFIX_ID
+            + "by the index number used in the displayed doctor list.\n" + "Parameters: "
+            + "INDEX (must be a positive integer) " + PREFIX_TAG + "TAG\n" + "Example: " + COMMAND_WORD + " "
             + "1 " + PREFIX_TAG + "healthy";
 
     public static final String MESSAGE_DELETE_TAG_SUCCESS = "Deleted tag from Doctor: %1$s";

--- a/src/main/java/seedu/plannermd/logic/commands/tagcommand/DeletePatientTagCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/tagcommand/DeletePatientTagCommand.java
@@ -2,7 +2,6 @@ package seedu.plannermd.logic.commands.tagcommand;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.plannermd.commons.core.Messages.MESSAGE_INVALID_PATIENT_DISPLAYED_INDEX;
-import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.HashSet;
@@ -22,8 +21,8 @@ import seedu.plannermd.model.tag.Tag;
 public class DeletePatientTagCommand extends DeleteTagCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a tag from the patient identified "
-            + "by the index number used in the displayed patient list.\n" + "Parameters: " + PREFIX_ID
-            + "ID (must be a positive integer) " + PREFIX_TAG + "TAG\n" + "Example: " + COMMAND_WORD + " " + PREFIX_ID
+            + "by the index number used in the displayed patient list.\n" + "Parameters: "
+            + "INDEX (must be a positive integer) " + PREFIX_TAG + "TAG\n" + "Example: " + COMMAND_WORD + " "
             + "1 " + PREFIX_TAG + "healthy";
 
     public static final String MESSAGE_DELETE_TAG_SUCCESS = "Deleted tag from Patient: %1$s";

--- a/src/main/java/seedu/plannermd/logic/commands/tagcommand/TagCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/tagcommand/TagCommand.java
@@ -1,5 +1,7 @@
 package seedu.plannermd.logic.commands.tagcommand;
 
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_ADD;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_DELETE;
 import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.plannermd.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -20,18 +22,18 @@ public abstract class TagCommand extends Command {
 
     public static final String COMMAND_WORD = "tag";
     public static final String MESSAGE_USAGE =
-            COMMAND_WORD + "{FLAG} {ARGUMENTS}: Executes appointment command given by flag tag\n"
+            COMMAND_WORD + "{FLAG} {ARGUMENTS}: Executes tag command given by flag tag\n"
             + "Commands: \n"
             + "tag -a: "
                     + "Adds a tag to the person identified by the index number used in the displayed person list.\n"
                     + "Parameters: "
                     + "INDEX (must be a positive integer) " + PREFIX_TAG + "TAG\n"
-                    + "Example: " + COMMAND_WORD + " " + "1 " + PREFIX_TAG + "healthy"
+                    + "Example: " + COMMAND_WORD + " " + FLAG_ADD + " " + "1 " + PREFIX_TAG + "healthy"
             + "tag -d: "
                     + "Deletes a tag to the person identified by the index number used in the displayed person list.\n"
                     + "Parameters: "
                     + "INDEX (must be a positive integer) " + PREFIX_TAG + "TAG\n"
-                    + "Example: " + COMMAND_WORD + " " + "1 " + PREFIX_TAG + "healthy";
+                    + "Example: " + COMMAND_WORD + " " + FLAG_DELETE + " " + "1 " + PREFIX_TAG + "healthy";
 
     /**
      * Updates the tags of the given doctor in the {@code model} and returns the edited doctor

--- a/src/main/java/seedu/plannermd/logic/commands/tagcommand/TagCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/tagcommand/TagCommand.java
@@ -1,5 +1,6 @@
 package seedu.plannermd.logic.commands.tagcommand;
 
+import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.plannermd.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.Set;
@@ -18,6 +19,19 @@ public abstract class TagCommand extends Command {
     public static final String TOO_MANY_TAGS_MESSAGE = "Please enter only one tag.";
 
     public static final String COMMAND_WORD = "tag";
+    public static final String MESSAGE_USAGE =
+            COMMAND_WORD + "{FLAG} {ARGUMENTS}: Executes appointment command given by flag tag\n"
+            + "Commands: \n"
+            + "tag -a: "
+                    + "Adds a tag to the person identified by the index number used in the displayed person list.\n"
+                    + "Parameters: "
+                    + "INDEX (must be a positive integer) " + PREFIX_TAG + "TAG\n"
+                    + "Example: " + COMMAND_WORD + " " + "1 " + PREFIX_TAG + "healthy"
+            + "tag -d: "
+                    + "Deletes a tag to the person identified by the index number used in the displayed person list.\n"
+                    + "Parameters: "
+                    + "INDEX (must be a positive integer) " + PREFIX_TAG + "TAG\n"
+                    + "Example: " + COMMAND_WORD + " " + "1 " + PREFIX_TAG + "healthy";
 
     /**
      * Updates the tags of the given doctor in the {@code model} and returns the edited doctor

--- a/src/main/java/seedu/plannermd/logic/parser/AppointmentCommandParser.java
+++ b/src/main/java/seedu/plannermd/logic/parser/AppointmentCommandParser.java
@@ -3,7 +3,7 @@ package seedu.plannermd.logic.parser;
 import static seedu.plannermd.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.plannermd.commons.core.Messages.MESSAGE_UNKNOWN_FLAG;
 import static seedu.plannermd.logic.parser.CliSyntax.FLAG_ADD;
-import static seedu.plannermd.logic.parser.CliSyntax.FLAG_DELETE_STRING;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_DELETE;
 import static seedu.plannermd.logic.parser.CliSyntax.FLAG_EDIT;
 import static seedu.plannermd.logic.parser.CliSyntax.FLAG_FILTER;
 import static seedu.plannermd.logic.parser.CliSyntax.FLAG_FILTER_UPCOMING;
@@ -12,7 +12,6 @@ import static seedu.plannermd.logic.parser.CliSyntax.FLAG_LIST;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.plannermd.logic.commands.HelpCommand;
 import seedu.plannermd.logic.commands.apptcommand.AddAppointmentCommand;
 import seedu.plannermd.logic.commands.apptcommand.AppointmentCommand;
 import seedu.plannermd.logic.commands.apptcommand.DeleteAppointmentCommand;
@@ -25,21 +24,21 @@ import seedu.plannermd.logic.parser.exceptions.ParseException;
 public class AppointmentCommandParser {
 
     /**
-     * Used for initial separation of command word and args.
+     * Used for initial separation of flag and args.
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<flag>\\S+)(?<arguments>.*)");
 
     /**
      * Parses user input into command for execution.
      *
-     * @param userInput full user input string
+     * @param userInput user input string containing flag and arguments
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
     public AppointmentCommand parseAppointmentCommand(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AppointmentCommand.MESSAGE_USAGE));
         }
 
         final String flag = matcher.group("flag");
@@ -52,7 +51,7 @@ public class AppointmentCommandParser {
         case FLAG_EDIT:
             return new EditAppointmentCommand();
 
-        case FLAG_DELETE_STRING:
+        case FLAG_DELETE:
             return new DeleteAppointmentCommand();
 
         case FLAG_FILTER:

--- a/src/main/java/seedu/plannermd/logic/parser/AppointmentCommandParser.java
+++ b/src/main/java/seedu/plannermd/logic/parser/AppointmentCommandParser.java
@@ -1,0 +1,71 @@
+package seedu.plannermd.logic.parser;
+
+import static seedu.plannermd.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.plannermd.commons.core.Messages.MESSAGE_UNKNOWN_FLAG;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_ADD;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_DELETE_STRING;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_EDIT;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_FILTER;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_FILTER_UPCOMING;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_LIST;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import seedu.plannermd.logic.commands.HelpCommand;
+import seedu.plannermd.logic.commands.apptcommand.AddAppointmentCommand;
+import seedu.plannermd.logic.commands.apptcommand.AppointmentCommand;
+import seedu.plannermd.logic.commands.apptcommand.DeleteAppointmentCommand;
+import seedu.plannermd.logic.commands.apptcommand.EditAppointmentCommand;
+import seedu.plannermd.logic.commands.apptcommand.FilterAppointmentCommand;
+import seedu.plannermd.logic.commands.apptcommand.FilterUpcomingAppointmentCommand;
+import seedu.plannermd.logic.commands.apptcommand.ListAppointmentCommand;
+import seedu.plannermd.logic.parser.exceptions.ParseException;
+
+public class AppointmentCommandParser {
+
+    /**
+     * Used for initial separation of command word and args.
+     */
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<flag>\\S+)(?<arguments>.*)");
+
+    /**
+     * Parses user input into command for execution.
+     *
+     * @param userInput full user input string
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AppointmentCommand parseAppointmentCommand(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String flag = matcher.group("flag");
+        final String arguments = matcher.group("arguments");
+
+        switch (flag) {
+        case FLAG_ADD:
+            return new AddAppointmentCommand();
+
+        case FLAG_EDIT:
+            return new EditAppointmentCommand();
+
+        case FLAG_DELETE_STRING:
+            return new DeleteAppointmentCommand();
+
+        case FLAG_FILTER:
+            return new FilterAppointmentCommand();
+
+        case FLAG_FILTER_UPCOMING:
+            return new FilterUpcomingAppointmentCommand();
+
+        case FLAG_LIST:
+            return new ListAppointmentCommand();
+
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_FLAG);
+        }
+    }
+}

--- a/src/main/java/seedu/plannermd/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/plannermd/logic/parser/CliSyntax.java
@@ -16,6 +16,21 @@ public class CliSyntax {
     public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_BIRTH_DATE = new Prefix("dob/");
     public static final Prefix PREFIX_RISK = new Prefix("risk/");
+
+    /* Appointment Prefix definitions */
+    public static final Prefix PREFIX_PATIENT = new Prefix("pat/");
+    public static final Prefix PREFIX_DOCTOR = new Prefix("d/");
+    public static final Prefix PREFIX_START = new Prefix("s/");
+    public static final Prefix PREFIX_END = new Prefix("e/");
+
     /* Flag definitions */
+    public static final String FLAG_ADD = "-a";
     public static final Flag FLAG_DELETE = new Flag("-d");
+    public static final String FLAG_DELETE_STRING = "-d";
+    public static final String FLAG_EDIT = "-e";
+    public static final String FLAG_FILTER = "-f";
+    public static final String FLAG_LIST = "-l";
+
+    /* Appointment Flag definitions */
+    public static final String FLAG_FILTER_UPCOMING = "-u";
 }

--- a/src/main/java/seedu/plannermd/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/plannermd/logic/parser/CliSyntax.java
@@ -8,25 +8,23 @@ public class CliSyntax {
 
     /* Prefix definitions */
     public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_PHONE = new Prefix("p/");
+    public static final Prefix PREFIX_PHONE = new Prefix("hp/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_ID = new Prefix("id/");
     public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_BIRTH_DATE = new Prefix("dob/");
     public static final Prefix PREFIX_RISK = new Prefix("risk/");
 
     /* Appointment Prefix definitions */
-    public static final Prefix PREFIX_PATIENT = new Prefix("pat/");
+    public static final Prefix PREFIX_PATIENT = new Prefix("p/");
     public static final Prefix PREFIX_DOCTOR = new Prefix("d/");
     public static final Prefix PREFIX_START = new Prefix("s/");
     public static final Prefix PREFIX_END = new Prefix("e/");
 
     /* Flag definitions */
     public static final String FLAG_ADD = "-a";
-    public static final Flag FLAG_DELETE = new Flag("-d");
-    public static final String FLAG_DELETE_STRING = "-d";
+    public static final String FLAG_DELETE = "-d";
     public static final String FLAG_EDIT = "-e";
     public static final String FLAG_FILTER = "-f";
     public static final String FLAG_LIST = "-l";

--- a/src/main/java/seedu/plannermd/logic/parser/PlannerMdParser.java
+++ b/src/main/java/seedu/plannermd/logic/parser/PlannerMdParser.java
@@ -13,6 +13,7 @@ import seedu.plannermd.logic.commands.HelpCommand;
 import seedu.plannermd.logic.commands.ToggleCommand;
 import seedu.plannermd.logic.commands.addcommand.AddDoctorCommand;
 import seedu.plannermd.logic.commands.addcommand.AddPatientCommand;
+import seedu.plannermd.logic.commands.apptcommand.AppointmentCommand;
 import seedu.plannermd.logic.commands.deletecommand.DeleteCommand;
 import seedu.plannermd.logic.commands.editcommand.EditCommand;
 import seedu.plannermd.logic.commands.findcommand.FindDoctorCommand;
@@ -62,16 +63,18 @@ public class PlannerMdParser {
         case ToggleCommand.COMMAND_WORD:
             return new ToggleCommand();
 
+        case AppointmentCommand.COMMAND_WORD:
+            return new AppointmentCommandParser().parseAppointmentCommand(userInput);
+
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
 
         default:
-        }
-
-        if (state.equals(State.PATIENT)) {
-            return parsePatientCommand(commandWord, arguments);
-        } else {
-            return parseDoctorCommand(commandWord, arguments);
+            if (state.equals(State.PATIENT)) {
+                return parsePatientCommand(commandWord, arguments);
+            } else {
+                return parseDoctorCommand(commandWord, arguments);
+            }
         }
     }
 

--- a/src/main/java/seedu/plannermd/logic/parser/TagCommandParser.java
+++ b/src/main/java/seedu/plannermd/logic/parser/TagCommandParser.java
@@ -4,9 +4,12 @@ import static java.util.Objects.requireNonNull;
 import static seedu.plannermd.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.plannermd.logic.commands.tagcommand.AddTagCommand.MESSAGE_NOT_ADDED;
 import static seedu.plannermd.logic.commands.tagcommand.TagCommand.TOO_MANY_TAGS_MESSAGE;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_ADD;
 import static seedu.plannermd.logic.parser.CliSyntax.FLAG_DELETE;
-import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import seedu.plannermd.commons.core.index.Index;
 import seedu.plannermd.commons.exceptions.IllegalValueException;
@@ -15,6 +18,8 @@ import seedu.plannermd.logic.parser.exceptions.ParseException;
 import seedu.plannermd.model.tag.Tag;
 
 public abstract class TagCommandParser implements Parser<TagCommand> {
+
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<flag>\\S+)(?<arguments>.*)");
 
     protected abstract String getUsageMessage();
     protected abstract TagCommand getAddTagCommand(Index index, Tag tag);
@@ -29,11 +34,19 @@ public abstract class TagCommandParser implements Parser<TagCommand> {
     @Override
     public TagCommand parse(String userInput) throws ParseException {
         requireNonNull(userInput);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_ID, PREFIX_TAG);
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, TagCommand.MESSAGE_USAGE));
+        }
+
+        final String flag = matcher.group("flag");
+        final String arguments = matcher.group("arguments");
+
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(arguments, PREFIX_TAG);
 
         Index index;
         try {
-            index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_ID).orElse(""));
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, getUsageMessage()), ive);
         }
@@ -50,10 +63,9 @@ public abstract class TagCommandParser implements Parser<TagCommand> {
 
         Tag tag = ParserUtil.parseTag(tagString);
 
-        String preamble = argMultimap.getPreamble();
-        if (preamble.equals("")) {
+        if (flag.equals(FLAG_ADD)) {
             return getAddTagCommand(index, tag);
-        } else if (preamble.equals(FLAG_DELETE.toString())) {
+        } else if (flag.equals(FLAG_DELETE)) {
             return getDeleteTagCommand(index, tag);
         } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, getUsageMessage()));

--- a/src/test/java/seedu/plannermd/logic/parser/AppointmentCommandParserTest.java
+++ b/src/test/java/seedu/plannermd/logic/parser/AppointmentCommandParserTest.java
@@ -6,7 +6,7 @@ import static seedu.plannermd.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.plannermd.logic.commands.HelpCommand;
+import seedu.plannermd.logic.commands.apptcommand.AppointmentCommand;
 import seedu.plannermd.logic.parser.exceptions.ParseException;
 
 class AppointmentCommandParserTest {
@@ -46,8 +46,8 @@ class AppointmentCommandParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), (
-        ) -> parser.parseAppointmentCommand(""));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AppointmentCommand.MESSAGE_USAGE), () -> parser.parseAppointmentCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/plannermd/logic/parser/AppointmentCommandParserTest.java
+++ b/src/test/java/seedu/plannermd/logic/parser/AppointmentCommandParserTest.java
@@ -1,0 +1,58 @@
+package seedu.plannermd.logic.parser;
+
+import static seedu.plannermd.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.plannermd.commons.core.Messages.MESSAGE_UNKNOWN_FLAG;
+import static seedu.plannermd.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.plannermd.logic.commands.HelpCommand;
+import seedu.plannermd.logic.parser.exceptions.ParseException;
+
+class AppointmentCommandParserTest {
+
+    private final AppointmentCommandParser parser = new AppointmentCommandParser();
+
+    //Appointment command integration tests
+    @Test
+    public void parseAppointmentCommand_addAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+    @Test
+    public void parseAppointmentCommand_deleteAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+    @Test
+    public void parseAppointmentCommand_editAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+    @Test
+    public void parseAppointmentCommand_filterAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+    @Test
+    public void parseAppointmentCommand_filterUpcomingAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+    @Test
+    public void parseAppointmentCommand_listAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+    @Test
+    public void parseCommand_unrecognisedInput_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), (
+        ) -> parser.parseAppointmentCommand(""));
+    }
+
+    @Test
+    public void parseCommand_unknownCommand_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_FLAG, (
+        )-> parser.parseAppointmentCommand("unknownCommand"));
+    }
+}

--- a/src/test/java/seedu/plannermd/logic/parser/PlannerMdParserTest.java
+++ b/src/test/java/seedu/plannermd/logic/parser/PlannerMdParserTest.java
@@ -75,6 +75,39 @@ public class PlannerMdParserTest {
         assertEquals(new AddDoctorCommand(doctor), doctorCommand);
     }
 
+    //Appointment command integration tests
+    @Test
+    public void parseCommand_addAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+    @Test
+    public void parseCommand_deleteAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+    @Test
+    public void parseCommand_editAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+    @Test
+    public void parseCommand_filterAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+    @Test
+    public void parseCommand_filterUpcomingAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+    @Test
+    public void parseCommand_listAppointmentCommand() throws Exception {
+        //TODO
+    }
+
+
+
     @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, patientState) instanceof ClearCommand);
@@ -214,11 +247,15 @@ public class PlannerMdParserTest {
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), (
             ) -> parser.parseCommand("", patientState));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), (
+            ) -> parser.parseCommand("", doctorState));
     }
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, (
-        )-> parser.parseCommand("unknownCommand", patientState));
+            )-> parser.parseCommand("unknownCommand", patientState));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, (
+            )-> parser.parseCommand("unknownCommand", doctorState));
     }
 }

--- a/src/test/java/seedu/plannermd/logic/parser/PlannerMdParserTest.java
+++ b/src/test/java/seedu/plannermd/logic/parser/PlannerMdParserTest.java
@@ -6,8 +6,8 @@ import static seedu.plannermd.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORM
 import static seedu.plannermd.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.plannermd.logic.commands.CommandTestUtil.REMARK_DESC_AMY;
 import static seedu.plannermd.logic.commands.CommandTestUtil.VALID_REMARK_AMY;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_ADD;
 import static seedu.plannermd.logic.parser.CliSyntax.FLAG_DELETE;
-import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.plannermd.testutil.Assert.assertThrows;
 import static seedu.plannermd.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -106,8 +106,6 @@ public class PlannerMdParserTest {
         //TODO
     }
 
-
-
     @Test
     public void parseCommand_clear() throws Exception {
         assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, patientState) instanceof ClearCommand);
@@ -160,13 +158,13 @@ public class PlannerMdParserTest {
 
         // Adding a tag
         AddPatientTagCommand addCommand = (AddPatientTagCommand) parser.parseCommand(
-                TagCommand.COMMAND_WORD + " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased() + " "
+                TagCommand.COMMAND_WORD + " " + FLAG_ADD + " " + INDEX_FIRST_PERSON.getOneBased() + " "
                         + PREFIX_TAG + validTag, State.PATIENT);
         assertEquals(new AddPatientTagCommand(INDEX_FIRST_PERSON, new Tag(validTag)), addCommand);
 
         // Deleting a tag
         DeletePatientTagCommand deleteCommand = (DeletePatientTagCommand) parser.parseCommand(
-                TagCommand.COMMAND_WORD + " " + FLAG_DELETE + " " + PREFIX_ID
+                TagCommand.COMMAND_WORD + " " + FLAG_DELETE + " "
                         + INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_TAG + validTag, State.PATIENT);
         assertEquals(new DeletePatientTagCommand(INDEX_FIRST_PERSON, new Tag(validTag)), deleteCommand);
     }
@@ -177,13 +175,13 @@ public class PlannerMdParserTest {
 
         // Adding a tag
         AddDoctorTagCommand addCommand = (AddDoctorTagCommand) parser.parseCommand(
-                TagCommand.COMMAND_WORD + " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased() + " "
+                TagCommand.COMMAND_WORD + " " + FLAG_ADD + " " + INDEX_FIRST_PERSON.getOneBased() + " "
                         + PREFIX_TAG + validTag, State.DOCTOR);
         assertEquals(new AddDoctorTagCommand(INDEX_FIRST_PERSON, new Tag(validTag)), addCommand);
 
         // Deleting a tag
         DeleteDoctorTagCommand deleteCommand = (DeleteDoctorTagCommand) parser.parseCommand(
-                TagCommand.COMMAND_WORD + " " + FLAG_DELETE + " " + PREFIX_ID
+                TagCommand.COMMAND_WORD + " " + FLAG_DELETE + " "
                         + INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_TAG + validTag, State.DOCTOR);
         assertEquals(new DeleteDoctorTagCommand(INDEX_FIRST_PERSON, new Tag(validTag)), deleteCommand);
     }

--- a/src/test/java/seedu/plannermd/logic/parser/TagDoctorCommandParserTest.java
+++ b/src/test/java/seedu/plannermd/logic/parser/TagDoctorCommandParserTest.java
@@ -2,8 +2,8 @@ package seedu.plannermd.logic.parser;
 
 import static seedu.plannermd.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.plannermd.logic.commands.tagcommand.TagCommand.TOO_MANY_TAGS_MESSAGE;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_ADD;
 import static seedu.plannermd.logic.parser.CliSyntax.FLAG_DELETE;
-import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.plannermd.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.plannermd.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -29,7 +29,7 @@ class TagDoctorCommandParserTest {
     @Test
     void parse_addIndexAndTagSpecified_success() {
         Index index = INDEX_FIRST_PERSON;
-        String userInput = " " + PREFIX_ID + index.getOneBased() + " " + PREFIX_TAG + VALID_TAG;
+        String userInput = FLAG_ADD + " " + index.getOneBased() + " " + PREFIX_TAG + VALID_TAG;
         AddDoctorTagCommand addDoctorTagCommand = new AddDoctorTagCommand(index, new Tag(VALID_TAG));
 
         assertParseSuccess(parser, userInput, addDoctorTagCommand);
@@ -38,30 +38,30 @@ class TagDoctorCommandParserTest {
     @Test
     void parse_addMissingFields_failure() {
         // missing index
-        assertParseFailure(parser, " " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, FLAG_ADD + " " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
 
         // missing tag
-        assertParseFailure(parser, " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased(),
+        assertParseFailure(parser, FLAG_ADD + " " + INDEX_FIRST_PERSON.getOneBased(),
                 AddDoctorTagCommand.MESSAGE_NOT_ADDED);
 
         // missing both index and tag
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, FLAG_ADD, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     void parse_addMultipleTags_failure() {
-        assertParseFailure(parser, " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased() + " "
+        assertParseFailure(parser, FLAG_ADD + " " + INDEX_FIRST_PERSON.getOneBased() + " "
                 + PREFIX_TAG + VALID_TAG + " " + PREFIX_TAG + "test", TOO_MANY_TAGS_MESSAGE);
     }
 
     @Test
     void parse_addInvalidValues_failure() {
         // invalid index
-        assertParseFailure(parser, " " + PREFIX_ID + "-1 " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, " " + PREFIX_ID + "a " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, FLAG_ADD + " " + "-1 " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, FLAG_ADD + " " + "a " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
 
         // invalid tag
-        assertParseFailure(parser, " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased()
+        assertParseFailure(parser, FLAG_ADD + " " + INDEX_FIRST_PERSON.getOneBased()
                         + " " + PREFIX_TAG + INVALID_TAG,
                 Tag.MESSAGE_CONSTRAINTS);
     }
@@ -69,7 +69,7 @@ class TagDoctorCommandParserTest {
     @Test
     void parse_deleteIndexAndTagSpecified_success() {
         Index index = INDEX_FIRST_PERSON;
-        String userInput = FLAG_DELETE + " " + PREFIX_ID + index.getOneBased() + " " + PREFIX_TAG + VALID_TAG;
+        String userInput = FLAG_DELETE + " " + index.getOneBased() + " " + PREFIX_TAG + VALID_TAG;
         DeleteDoctorTagCommand deleteDoctorTagCommand = new DeleteDoctorTagCommand(index, new Tag(VALID_TAG));
 
         assertParseSuccess(parser, userInput, deleteDoctorTagCommand);
@@ -82,7 +82,7 @@ class TagDoctorCommandParserTest {
                 MESSAGE_INVALID_FORMAT);
 
         // missing tag
-        assertParseFailure(parser, FLAG_DELETE + " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased(),
+        assertParseFailure(parser, FLAG_DELETE + " " + INDEX_FIRST_PERSON.getOneBased(),
                 AddDoctorTagCommand.MESSAGE_NOT_ADDED);
 
         // missing both index and tag
@@ -92,35 +92,35 @@ class TagDoctorCommandParserTest {
     @Test
     void parse_deleteInvalidValues_failure() {
         // invalid index
-        assertParseFailure(parser, FLAG_DELETE + " " + PREFIX_ID + "-1 " + PREFIX_TAG + VALID_TAG,
+        assertParseFailure(parser, FLAG_DELETE + " " + "-1 " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, FLAG_DELETE + " " + PREFIX_ID + "a " + PREFIX_TAG + VALID_TAG,
+        assertParseFailure(parser, FLAG_DELETE + " " + "a " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
 
         // invalid tag
-        assertParseFailure(parser, FLAG_DELETE + " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased()
+        assertParseFailure(parser, FLAG_DELETE + " " + INDEX_FIRST_PERSON.getOneBased()
                         + " " + PREFIX_TAG + INVALID_TAG,
                 Tag.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     void parse_deleteMultipleTags_failure() {
-        assertParseFailure(parser, FLAG_DELETE + " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased()
+        assertParseFailure(parser, FLAG_DELETE + " " + INDEX_FIRST_PERSON.getOneBased()
                 + " " + PREFIX_TAG + VALID_TAG + " " + PREFIX_TAG + "test", TOO_MANY_TAGS_MESSAGE);
     }
 
     @Test
-    void parse_invalidPreamble_failure() {
-        assertParseFailure(parser, "1 " + PREFIX_ID + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
+    void parse_invalidFlag_failure() {
+        assertParseFailure(parser, "1 " + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
 
-        assertParseFailure(parser, "d " + PREFIX_ID + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
+        assertParseFailure(parser, "d " + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
 
-        assertParseFailure(parser, "-z " + PREFIX_ID + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
+        assertParseFailure(parser, "-z " + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
 
-        assertParseFailure(parser, "random string " + PREFIX_ID + INDEX_FIRST_PERSON
+        assertParseFailure(parser, "random string " + INDEX_FIRST_PERSON
                         + " " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
     }

--- a/src/test/java/seedu/plannermd/logic/parser/TagPatientCommandParserTest.java
+++ b/src/test/java/seedu/plannermd/logic/parser/TagPatientCommandParserTest.java
@@ -29,7 +29,7 @@ class TagPatientCommandParserTest {
     @Test
     void parse_addIndexAndTagSpecified_success() {
         Index index = INDEX_FIRST_PERSON;
-        String userInput = FLAG_ADD + " " + " " + index.getOneBased() + " " + PREFIX_TAG + VALID_TAG;
+        String userInput = FLAG_ADD + " " + index.getOneBased() + " " + PREFIX_TAG + VALID_TAG;
         AddPatientTagCommand addPatientTagCommand = new AddPatientTagCommand(index, new Tag(VALID_TAG));
 
         assertParseSuccess(parser, userInput, addPatientTagCommand);

--- a/src/test/java/seedu/plannermd/logic/parser/TagPatientCommandParserTest.java
+++ b/src/test/java/seedu/plannermd/logic/parser/TagPatientCommandParserTest.java
@@ -2,8 +2,8 @@ package seedu.plannermd.logic.parser;
 
 import static seedu.plannermd.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.plannermd.logic.commands.tagcommand.TagCommand.TOO_MANY_TAGS_MESSAGE;
+import static seedu.plannermd.logic.parser.CliSyntax.FLAG_ADD;
 import static seedu.plannermd.logic.parser.CliSyntax.FLAG_DELETE;
-import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.plannermd.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.plannermd.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.plannermd.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -29,7 +29,7 @@ class TagPatientCommandParserTest {
     @Test
     void parse_addIndexAndTagSpecified_success() {
         Index index = INDEX_FIRST_PERSON;
-        String userInput = " " + PREFIX_ID + index.getOneBased() + " " + PREFIX_TAG + VALID_TAG;
+        String userInput = FLAG_ADD + " " + " " + index.getOneBased() + " " + PREFIX_TAG + VALID_TAG;
         AddPatientTagCommand addPatientTagCommand = new AddPatientTagCommand(index, new Tag(VALID_TAG));
 
         assertParseSuccess(parser, userInput, addPatientTagCommand);
@@ -38,30 +38,30 @@ class TagPatientCommandParserTest {
     @Test
     void parse_addMissingFields_failure() {
         // missing index
-        assertParseFailure(parser, " " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, FLAG_ADD + " " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
 
         // missing tag
-        assertParseFailure(parser, " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased(),
+        assertParseFailure(parser, FLAG_ADD + " " + INDEX_FIRST_PERSON.getOneBased(),
                 AddPatientTagCommand.MESSAGE_NOT_ADDED);
 
         // missing both index and tag
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, FLAG_ADD, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     void parse_addMultipleTags_failure() {
-        assertParseFailure(parser, " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased() + " "
+        assertParseFailure(parser, FLAG_ADD + " " + INDEX_FIRST_PERSON.getOneBased() + " "
                 + PREFIX_TAG + VALID_TAG + " " + PREFIX_TAG + "test", TOO_MANY_TAGS_MESSAGE);
     }
 
     @Test
     void parse_addInvalidValues_failure() {
         // invalid index
-        assertParseFailure(parser, " " + PREFIX_ID + "-1 " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, " " + PREFIX_ID + "a " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, FLAG_ADD + " " + "-1 " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, FLAG_ADD + " " + "a " + PREFIX_TAG + VALID_TAG, MESSAGE_INVALID_FORMAT);
 
         // invalid tag
-        assertParseFailure(parser, " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased()
+        assertParseFailure(parser, FLAG_ADD + " " + INDEX_FIRST_PERSON.getOneBased()
                         + " " + PREFIX_TAG + INVALID_TAG,
                 Tag.MESSAGE_CONSTRAINTS);
     }
@@ -69,7 +69,7 @@ class TagPatientCommandParserTest {
     @Test
     void parse_deleteIndexAndTagSpecified_success() {
         Index index = INDEX_FIRST_PERSON;
-        String userInput = FLAG_DELETE + " " + PREFIX_ID + index.getOneBased() + " " + PREFIX_TAG + VALID_TAG;
+        String userInput = FLAG_DELETE + " " + index.getOneBased() + " " + PREFIX_TAG + VALID_TAG;
         DeletePatientTagCommand deletePatientTagCommand = new DeletePatientTagCommand(index, new Tag(VALID_TAG));
 
         assertParseSuccess(parser, userInput, deletePatientTagCommand);
@@ -82,45 +82,45 @@ class TagPatientCommandParserTest {
                 MESSAGE_INVALID_FORMAT);
 
         // missing tag
-        assertParseFailure(parser, FLAG_DELETE + " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased(),
+        assertParseFailure(parser, FLAG_DELETE + " " + INDEX_FIRST_PERSON.getOneBased(),
                 AddPatientTagCommand.MESSAGE_NOT_ADDED);
 
         // missing both index and tag
-        assertParseFailure(parser, FLAG_DELETE.toString(), MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, FLAG_DELETE, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     void parse_deleteInvalidValues_failure() {
         // invalid index
-        assertParseFailure(parser, FLAG_DELETE + " " + PREFIX_ID + "-1 " + PREFIX_TAG + VALID_TAG,
+        assertParseFailure(parser, FLAG_DELETE + " " + "-1 " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
-        assertParseFailure(parser, FLAG_DELETE + " " + PREFIX_ID + "a " + PREFIX_TAG + VALID_TAG,
+        assertParseFailure(parser, FLAG_DELETE + " " + "a " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
 
         // invalid tag
-        assertParseFailure(parser, FLAG_DELETE + " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased()
+        assertParseFailure(parser, FLAG_DELETE + " " + INDEX_FIRST_PERSON.getOneBased()
                         + " " + PREFIX_TAG + INVALID_TAG,
                 Tag.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     void parse_deleteMultipleTags_failure() {
-        assertParseFailure(parser, FLAG_DELETE + " " + PREFIX_ID + INDEX_FIRST_PERSON.getOneBased()
+        assertParseFailure(parser, FLAG_DELETE + " " + INDEX_FIRST_PERSON.getOneBased()
                 + " " + PREFIX_TAG + VALID_TAG + " " + PREFIX_TAG + "test", TOO_MANY_TAGS_MESSAGE);
     }
 
     @Test
-    void parse_invalidPreamble_failure() {
-        assertParseFailure(parser, "1 " + PREFIX_ID + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
+    void parse_invalidFlag_failure() {
+        assertParseFailure(parser, "1 " + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
 
-        assertParseFailure(parser, "d " + PREFIX_ID + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
+        assertParseFailure(parser, "d " + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
 
-        assertParseFailure(parser, "-z " + PREFIX_ID + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
+        assertParseFailure(parser, "-z " + INDEX_FIRST_PERSON + " " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
 
-        assertParseFailure(parser, "random string " + PREFIX_ID + INDEX_FIRST_PERSON
+        assertParseFailure(parser, "random string " + INDEX_FIRST_PERSON
                         + " " + PREFIX_TAG + VALID_TAG,
                 MESSAGE_INVALID_FORMAT);
     }


### PR DESCRIPTION
Update `parseCommand` to support appt commands

Add AppointmentCommand and skeletons of propose Appointment commands
Add AppointmentCommand flags
Add AppointmentCommands prefixes

Add AppointmentCommandParser to parse flags inputted

Considerations
 * Whether a flag is necessary for add appointment to be consistent with `tag`
 * Necessity of flags since switch requires constant expressions. Should we want to use the flags perhaps we can implement another multimap to parse them. Perhaps we could update tags to be consistent based on our change
 * Problematic `/p` prefix already used for phone, `patient` probably needs another

Todos
 * Update test suites when builders are available
