### PR TITLE
Fix bug for editing appointments

### DIFF
--- a/src/main/java/seedu/plannermd/logic/commands/apptcommand/EditAppointmentCommand.java
+++ b/src/main/java/seedu/plannermd/logic/commands/apptcommand/EditAppointmentCommand.java
@@ -43,7 +43,6 @@ public class EditAppointmentCommand extends AppointmentCommand {
 
     public static final String MESSAGE_EDIT_APPOINTMENT_SUCCESS = "Edited Appointment: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_APPOINTMENT = "This appointment already exists in the plannermd.";
     public static final String MESSAGE_CLASHING_APPOINTMENT = "This appointment clashes with an existing appointment.";
     public static final String MESSAGE_INVALID_START = "Start date/time should be of the format DD/MM/YYYY HH:MM "
             + "and adhere to the following constraints:\n"
@@ -80,11 +79,7 @@ public class EditAppointmentCommand extends AppointmentCommand {
         Appointment appointmentToEdit = lastShownList.get(index.getZeroBased());
         Appointment editedAppointment = createEditedAppointment(appointmentToEdit, editAppointmentDescriptor, model);
 
-        if (model.hasAppointment(editedAppointment)) {
-            throw new CommandException(MESSAGE_DUPLICATE_APPOINTMENT);
-        }
-
-        if (model.isClashAppointment(editedAppointment)) {
+        if (model.isClashAppointmentForEdited(editedAppointment, appointmentToEdit)) {
             throw new CommandException(MESSAGE_CLASHING_APPOINTMENT);
         }
 

--- a/src/main/java/seedu/plannermd/model/Model.java
+++ b/src/main/java/seedu/plannermd/model/Model.java
@@ -146,6 +146,14 @@ public interface Model {
     boolean isClashAppointment(Appointment appointment);
 
     /**
+     * Returns true if an edited appointment clashes with {@code appointment} in the PlannerMD.
+     *
+     * @param editedAppointment The appointment that is edited.
+     * @param oldAppointment    The appointment before applying the changes.
+     */
+    boolean isClashAppointmentForEdited(Appointment editedAppointment, Appointment oldAppointment);
+
+    /**
      * Deletes the given appointment.
      * The appointment must exist in the PlannerMD.
      */

--- a/src/main/java/seedu/plannermd/model/ModelManager.java
+++ b/src/main/java/seedu/plannermd/model/ModelManager.java
@@ -185,6 +185,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean isClashAppointmentForEdited(Appointment editedAppointment, Appointment oldAppointment) {
+        requireAllNonNull(editedAppointment, oldAppointment);
+        return plannerMd.isClashAppointmentForEdited(editedAppointment, oldAppointment);
+    }
+
+    @Override
     public void deleteAppointment(Appointment target) {
         plannerMd.removeAppointment(target);
     }

--- a/src/main/java/seedu/plannermd/model/PlannerMd.java
+++ b/src/main/java/seedu/plannermd/model/PlannerMd.java
@@ -1,6 +1,7 @@
 package seedu.plannermd.model;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.plannermd.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.List;
 import java.util.Objects;
@@ -37,7 +38,8 @@ public class PlannerMd implements ReadOnlyPlannerMd {
         appointments = new UniqueAppointmentList();
     }
 
-    public PlannerMd() {}
+    public PlannerMd() {
+    }
 
     /**
      * Creates an PlannerMd using the Persons in the {@code toBeCopied}
@@ -199,6 +201,27 @@ public class PlannerMd implements ReadOnlyPlannerMd {
     }
 
     /**
+     * Returns true if an existing appointment clashes with the edited appointment in the PlannerMD.
+     *
+     * @param editedAppointment The appointment that is edited.
+     * @param oldAppointment    The appointment before applying the changes.
+     */
+    public boolean isClashAppointmentForEdited(Appointment editedAppointment, Appointment oldAppointment) {
+        requireAllNonNull(editedAppointment, oldAppointment);
+        for (Appointment existingAppointment : appointments) {
+            if (oldAppointment.isSameAppointment(existingAppointment)) {
+                // skip comparing, otherwise the edited appointment will almost always
+                // clash with itself before the changes
+                continue;
+            }
+            if (editedAppointment.isClash(existingAppointment)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Adds an appointment to the PlannerMD.
      * The appointment must not already exist in the PlannerMD.
      */
@@ -229,7 +252,7 @@ public class PlannerMd implements ReadOnlyPlannerMd {
      * Deletes appointments with {@code person} from the appointment list
      *
      * @param person person whose appointments should be deleted
-     * @param <T> Subtype of Person
+     * @param <T>    Subtype of Person
      */
     public <T extends Person> void deleteAppointmentsWithPerson(T person) {
         appointments.deleteAppointmentsWithPerson(person);
@@ -238,9 +261,9 @@ public class PlannerMd implements ReadOnlyPlannerMd {
     /**
      * Updates appointments with {@code person} to {@code editedPerson} from the appointment list
      *
-     * @param person person whose appointments should be updated
+     * @param person       person whose appointments should be updated
      * @param editedPerson the person to replace {@code person} in existing appointments
-     * @param <T> Subtype of Person
+     * @param <T>          Subtype of Person
      */
     public <T extends Person> void editAppointmentsWithPerson(T person, T editedPerson) {
         appointments.editAppointmentsWithPerson(person, editedPerson);

--- a/src/test/java/seedu/plannermd/logic/commands/AddAppointmentCommandTest.java
+++ b/src/test/java/seedu/plannermd/logic/commands/AddAppointmentCommandTest.java
@@ -40,6 +40,7 @@ import seedu.plannermd.testutil.patient.PatientBuilder;
 public class AddAppointmentCommandTest {
     private AddAppointmentCommand.AddAppointmentDescriptor descriptor =
             new AddAppointmentDescriptorBuilder(new AppointmentBuilder().build()).build();
+
     @Test
     public void constructor_nullAll_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new AddAppointmentCommand(null,
@@ -131,7 +132,7 @@ public class AddAppointmentCommandTest {
         // same values -> returns true
         AddAppointmentCommand addThirtyMinApptCommandCopy =
                 new AddAppointmentCommand(INDEX_FIRST_PERSON, INDEX_FIRST_PERSON,
-                new AddAppointmentDescriptorBuilder(thirtyMinDescriptor).build());
+                        new AddAppointmentDescriptorBuilder(thirtyMinDescriptor).build());
 
         assertTrue(addThirtyMinApptCommand.equals(addThirtyMinApptCommandCopy));
 
@@ -251,6 +252,11 @@ public class AddAppointmentCommandTest {
 
         @Override
         public boolean isClashAppointment(Appointment appointment) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean isClashAppointmentForEdited(Appointment editedAppointment, Appointment oldAppointment) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -401,7 +407,6 @@ public class AddAppointmentCommandTest {
             }
             return false;
         }
-
 
 
         @Override

--- a/src/test/java/seedu/plannermd/logic/commands/AddDoctorCommandTest.java
+++ b/src/test/java/seedu/plannermd/logic/commands/AddDoctorCommandTest.java
@@ -185,6 +185,11 @@ public class AddDoctorCommandTest {
         }
 
         @Override
+        public boolean isClashAppointmentForEdited(Appointment editedAppointment, Appointment oldAppointment) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasAppointment(Appointment appointment) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/plannermd/logic/commands/AddPatientCommandTest.java
+++ b/src/test/java/seedu/plannermd/logic/commands/AddPatientCommandTest.java
@@ -184,6 +184,11 @@ public class AddPatientCommandTest {
         }
 
         @Override
+        public boolean isClashAppointmentForEdited(Appointment editedAppointment, Appointment oldAppointment) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasAppointment(Appointment appointment) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/plannermd/logic/commands/EditAppointmentCommandTest.java
+++ b/src/test/java/seedu/plannermd/logic/commands/EditAppointmentCommandTest.java
@@ -120,7 +120,7 @@ public class EditAppointmentCommandTest {
                         .build();
         EditAppointmentCommand editAppointmentCommand = new EditAppointmentCommand(INDEX_SECOND_PERSON, descriptor);
 
-        assertCommandFailure(editAppointmentCommand, model, EditAppointmentCommand.MESSAGE_DUPLICATE_APPOINTMENT);
+        assertCommandFailure(editAppointmentCommand, model, EditAppointmentCommand.MESSAGE_CLASHING_APPOINTMENT);
     }
 
     @Test


### PR DESCRIPTION
Previously when editing an appointment, the edited appointment is checked against existing appointments for clashes. However, it also checks against itself (the original copy in the list) and will result in clashes when that isn't the case. I modified the method responsible for the checking and it should work now.