### PR TITLE
Allow names, emails and addresses that are too long to wrap

### DIFF
--- a/src/main/resources/view/AppointmentListCard.fxml
+++ b/src/main/resources/view/AppointmentListCard.fxml
@@ -34,8 +34,8 @@
                 <FlowPane fx:id="risk" />
             </HBox>
             <Label fx:id="apptTime" styleClass="cell_small_label" text="\$apptTime" />
-            <Label fx:id="doctorName" styleClass="cell_small_label" text="\$doctorName"/>
-            <Label fx:id="patientName" styleClass="cell_small_label" text="\$patientName"/>
+            <Label fx:id="doctorName" styleClass="cell_small_label" text="\$doctorName" wrapText="true"/>
+            <Label fx:id="patientName" styleClass="cell_small_label" text="\$patientName" wrapText="true"/>
             <Label fx:id="remarks" styleClass="cell_small_label" wrapText="true" text="\$remarks"/>
         </VBox>
     </GridPane>

--- a/src/main/resources/view/DoctorListCard.fxml
+++ b/src/main/resources/view/DoctorListCard.fxml
@@ -25,13 +25,13 @@
                         <Region fx:constant="USE_PREF_SIZE" />
                     </minWidth>
                 </Label>
-                <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+                <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true" />
             </HBox>
             <FlowPane fx:id="tags" minWidth="-Infinity"/>
             <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
             <Label fx:id="dateOfBirth" styleClass="cell_small_label" text="\$dateOfBirth" />
-            <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-            <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+            <Label fx:id="address" styleClass="cell_small_label" text="\$address" wrapText="true"/>
+            <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true"/>
             <Label fx:id="remark" styleClass="cell_small_label" text="\$remark" wrapText="true"/>
         </VBox>
     </GridPane>

--- a/src/main/resources/view/PatientListCard.fxml
+++ b/src/main/resources/view/PatientListCard.fxml
@@ -25,14 +25,14 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
-        <FlowPane fx:id="risk" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true" />
+        <FlowPane fx:id="risk" alignment="CENTER_LEFT" />
       </HBox>
       <FlowPane fx:id="tags" minWidth="-Infinity" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="dateOfBirth" styleClass="cell_small_label" text="\$dateOfBirth" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="address" styleClass="cell_small_label" text="\$address" wrapText="true"/>
+      <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true"/>
       <Label fx:id="remark" styleClass="cell_small_label" text="\$remark" wrapText="true" />
     </VBox>
   </GridPane>


### PR DESCRIPTION
names that are too long can now wrap
![Screenshot 2021-11-03 at 22 01 43](https://user-images.githubusercontent.com/65447873/140075368-6b21faf6-3765-4383-83f4-0ef732cf7d38.png)
The patient name layout has been updated to the one above so as to wrap when there is a name that is too long.
![Screenshot 2021-11-03 at 21 52 37](https://user-images.githubusercontent.com/65447873/140075495-caba56b9-c61c-4dd2-bbf0-7bb4ad3f651a.png)


